### PR TITLE
V键计算器底层重构，计算函数解耦，新增功能

### DIFF
--- a/lua/calculator.lua
+++ b/lua/calculator.lua
@@ -14,36 +14,210 @@ local function truncateFromStart(str, truncateStr)
   return string.sub(str, string.len(truncateStr) + 1)
 end
 
-local function replaceMathFunc(express)
-  -- 不使用string.gsub(str, "SIN%(([0-9]+)%)", "math.sin(%1)"), 因为无法处理SIN(SIN(x))这种情况
-  -- 转大写避免重复替换, 空格是为了给第一个[^A-z]留空间
-  local str = " " .. string.upper(express)
-  str = string.gsub(str, "([^A-z])ASIN%(", "%1math.asin(")     -- 反正弦
-  str = string.gsub(str, "([^A-z])SINH%(", "%1math.sinh(")     -- 双曲正弦
-  str = string.gsub(str, "([^A-z])SIN%(", "%1math.sin(")       -- 正弦
-  str = string.gsub(str, "([^A-z])ACOS%(", "%1math.acos(")     -- 反余弦
-  str = string.gsub(str, "([^A-z])COSH%(", "%1math.cosh(")     -- 双曲余弦
-  str = string.gsub(str, "([^A-z])COS%(", "%1math.cos(")       -- 余弦
-  str = string.gsub(str, "([^A-z])ATAN2%(", "%1math.atan2(")   -- atan2(y,x). 返回y/x的反正切(以弧度为单位), 但使用两个参数的符号来查找结果的象限.
-  str = string.gsub(str, "([^A-z])ATAN%(", "%1math.atan(")     -- 反正切
-  str = string.gsub(str, "([^A-z])TANH%(", "%1math.tanh(")     -- 双曲正切
-  str = string.gsub(str, "([^A-z])TAN%(", "%1math.tan(")       -- 正切
-  str = string.gsub(str, "([^A-z])DEG%(", "%1math.deg(")       -- 以度为单位返回角度x
-  str = string.gsub(str, "([^A-z])RAD%(", "%1math.rad(")       -- 以弧度为单位返回角度x
-  -- str = string.gsub(str, "([^A-z])FREXP%(", "%1math.frexp(")   -- frexp(x). 返回m,e 使得x = m*2^e
-  -- str = string.gsub(str, "([^A-z])LDEXP%(", "%1math.ldexp(")   -- ldexp(m, e). 返回m*2^e
-  str = string.gsub(str, "([^A-z])EXP%(", "%1math.exp(")       -- exp(x). e的x次幂
-  str = string.gsub(str, "([^A-z])LOG10%(", "%1math.log10(")   -- 以10为底的对数
-  str = string.gsub(str, "([^A-z])LOG%(", "%1math.log(")       -- 自然对数(e为底)
-  str = string.gsub(str, "([^A-z])RANDOM%(", "%1math.random(") -- random([m[, n]]), m - n 之间的随机数
-  str = string.gsub(str, "([^A-z])SQRT%(", "%1math.sqrt(")     -- x的平方根. 等于x^0.5
-  str = string.gsub(str, "([^A-z])PI", "%1math.pi")            -- π
-  -- 去除第一个字符(手动添加的空格)
-  return string.sub(str, 2)
+-- 函数表
+local calcPlugin = {
+  -- e, exp(1) = e^1 = e
+  e = math.exp(1),
+  -- π
+  pi = math.pi
+}
+
+-- random([m [,n ]]) 返回m-n之间的随机数, n为空则返回1-m之间, 都为空则返回0-1之间的小数
+local function random(...)
+  return math.random(...)
+end
+-- 注册到函数表中
+calcPlugin["rdm"] = random
+
+-- 正弦
+local function sin(x)
+  return math.sin(x)
+end
+calcPlugin["sin"] = sin
+
+-- 双曲正弦
+local function sinh(x)
+  return math.sinh(x)
+end
+calcPlugin["sinh"] = sinh
+
+-- 反正弦
+local function asin(x)
+  return math.asin(x)
+end
+calcPlugin["asin"] = asin
+
+-- 余弦
+local function cos(x)
+  return math.cos(x)
+end
+calcPlugin["cos"] = cos
+
+-- 双曲余弦
+local function cosh(x)
+  return math.cosh(x)
+end
+calcPlugin["cosh"] = cosh
+
+-- 反余弦
+local function acos(x)
+  return math.acos(x)
+end
+calcPlugin["acos"] = acos
+
+-- 正切
+local function tan(x)
+  return math.tan(x)
+end
+calcPlugin["tan"] = tan
+
+-- 双曲正切
+local function tanh(x)
+  return math.tanh(x)
+end
+calcPlugin["tanh"] = tanh
+
+-- 反正切
+local function atan(x)
+  return math.atan(x)
+end
+calcPlugin["atan"] = atan
+
+-- 返回以弧度为单位的点(x,y)相对于x轴的逆时针角度。y是点的纵坐标，x是点的横坐标
+-- 返回范围从−π到π （以弧度为单位），其中负角度表示向下旋转，正角度表示向上旋转
+-- 它与传统的 math.atan(y/x) 函数相比，具有更好的数学定义，因为它能够正确处理边界情况（例如x=0）
+local function atan2(y, x)
+  return math.atan2(y, x)
+end
+calcPlugin["atan2"] = atan2
+
+-- 将角度从弧度转换为度 e.g. deg(π) = 180
+local function deg(x)
+  return math.deg(x)
+end
+calcPlugin["deg"] = deg
+
+-- 将角度从度转换为弧度 e.g. rad(180) = π
+local function rad(x)
+  return math.rad(x)
+end
+calcPlugin["rad"] = rad
+
+-- 返回两个值, 无法参与运算后续
+-- 返回m,e 使得x = m*2^e
+-- local function frexp(x)
+--   return math.frexp(x)
+-- end
+-- calcPlugin["frexp"] = frexp
+
+-- 返回 x*2^y
+local function ldexp(x, y)
+  return math.ldexp(x, y)
+end
+calcPlugin["ldexp"] = ldexp
+
+-- 返回 e^x
+local function exp(x)
+  return math.exp(x)
+end
+calcPlugin["exp"] = exp
+
+-- 返回x的平方根 e.g. sqrt(x) = x^0.5
+local function sqrt(x)
+  return math.sqrt(x)
+end
+calcPlugin["sqrt"] = sqrt
+
+-- x为底的对数, log(10, 100) = log(100) / log(10) = 2
+local function log(x, y)
+  -- 不能为负数或0
+  if x <= 0 or y <= 0 then return nil end
+
+  return math.log(y) / math.log(x)
+end
+calcPlugin["log"] = log
+
+-- 自然数e为底的对数
+local function loge(x)
+  -- 不能为负数或0
+  if x <= 0 then return nil end
+
+  return math.log(x)
+end
+calcPlugin["loge"] = loge
+
+-- 10为底的对数
+local function log10(x)
+  -- 不能为负数或0
+  if x <= 0 then return nil end
+
+  return math.log10(x)
+end
+calcPlugin["log10"] = log10
+
+-- 平均值
+local function avg(...)
+  local data = {...}
+  local n = select("#", ...)
+  -- 样本数量不能为0
+  if n == 0 then return nil end
+
+  -- 计算总和
+  local sum = 0
+  for _, value in ipairs(data) do
+    sum = sum + value
+  end
+
+  return sum / n
+end
+calcPlugin["avg"] = avg
+
+-- 方差
+local function variance(...)
+  local data = {...}
+  local n = select("#", ...)
+  -- 样本数量不能为0
+  if n == 0 then return nil end
+
+  -- 计算均值
+  local sum = 0
+  for _, value in ipairs(data) do
+    sum = sum + value
+  end
+  local mean = sum / n
+
+  -- 计算方差
+  local sum_squared_diff = 0
+  for _, value in ipairs(data) do
+    sum_squared_diff = sum_squared_diff + (value - mean)^2
+  end
+
+  return sum_squared_diff / n
+end
+calcPlugin["var"] = variance
+
+-- 阶乘
+local function factorial(x)
+  -- 不能为负数
+  if x < 0 then return nil end
+  if x == 0 or x == 1 then return 1 end
+
+  local result = 1
+  for i = 1, x do
+    result = result * i
+  end
+
+  return result
+end
+calcPlugin["fact"] = factorial
+
+-- 实现阶乘计算(!)
+local function replaceToFactorial(str)
+  -- 替换[0-9]!字符为fact([0-9])以实现阶乘
+  return str:gsub("([0-9]+)!", "fact(%1)")
 end
 
 -- 简单计算器
--- BUG: 不支持小键盘 + - * /
 function M.func(input, seg, env)
   if not startsWith(input, M.prefix) then return end
   -- 提取算式
@@ -51,13 +225,14 @@ function M.func(input, seg, env)
   -- 算式长度 < 2 直接终止(没有计算意义)
   if (string.len(express) < 2) then return end
   -- pcall()的原因需要控制一下 . 符号的位置
-  if (string.match(express, "[^0-9]%.")) then
-    yield(Candidate(input, seg.start, seg._end, express, "小数点不能在非数字字符后面"))
-    return
-  end
+  -- 现在不需要了
+  -- if (string.match(express, "[^0-9]%.")) then
+  --   yield(Candidate(input, seg.start, seg._end, express, "小数点不能在非数字字符后面"))
+  --   return
+  -- end
+  local code = replaceToFactorial(express)
 
-  local code = replaceMathFunc(express)
-  local success, result = pcall(load("return " .. code))
+  local success, result = pcall(load("return " .. code, "calculate", "t", calcPlugin))
   if success then
     yield(Candidate(input, seg.start, seg._end, result, ""))
     yield(Candidate(input, seg.start, seg._end, express .. "=" .. result, ""))


### PR DESCRIPTION
新增 阶乘、平均数、方差、随机数、弧度转度、度转弧度、对数 计算支持

更改pcall调用方式避免全局函数误调用

计算函数与核心逻辑解耦，方便后续添加

输入e调用e (需要在计算上下文中)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/e9db9aba-ec36-4e58-8f74-4afafa6e370e)

输入pi调用π (可直接调用)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/564bb50f-64c3-419d-a385-18181d55042d)

目前已实现函数
-- 随机数
rdm(...)
![动画](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/da9af3e2-d642-4bb7-a607-b1e4157ac993)


-- 正弦
sin(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/d71c474d-5c96-4f16-a22b-af18ff9d96da)


-- 双曲正弦
sinh(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/078881b6-6efe-47aa-a6e5-17727b98d33f)


-- 反正弦
asin(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/4bd15b0c-bcda-4f0b-b505-1b3d1e32308b)


-- 余弦
cos(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/0e071320-0db7-4bf3-ba8d-c1312b4abd97)


-- 双曲余弦
cosh(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/c997812d-8e48-463f-8ccf-dbd04dd5b169)


-- 反余弦
acos(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/003dc76a-5146-4e4d-98e0-82d438c05750)


-- 正切
tan(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/dc5c321c-ff9a-42b2-8692-6501cd635f49)


-- 双曲正切
tanh(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/d8eea1f9-0431-4849-ac59-656a6bc8bc0a)


-- 反正切
atan(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/52b139f0-8705-4ec7-ab6b-db9499ceac62)


-- 返回以弧度为单位的点(x,y)相对于x轴的逆时针角度。y是点的纵坐标，x是点的横坐标
-- 返回范围从−π到π （以弧度为单位），其中负角度表示向下旋转，正角度表示向上旋转
-- 与atan(y/x)相比，能够正确处理边界情况（例如x=0）
atan2(y, x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/d39af35f-a40c-4b4c-9707-ee27a06e5960)


-- 将角度从弧度转换为度
deg(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/0539f2e4-41bb-4702-ad68-40329f796a37)


-- 将角度从度转换为弧度
rad(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/9094135a-38dd-49aa-951a-d88e19bc2728)


-- 返回 x*2^y
ldexp(x, y)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/cb47a715-1572-4607-b78e-3ac244cd890b)


-- 返回 e^x
exp(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/71422945-fdf4-457f-bdca-969670929d68)


-- x的平方根 sqrt(x) = x^0.5
sqrt(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/8bad3d91-e69f-463e-993b-873ccdd46eff)


-- x为底的对数, log(10, 100) = log(100) / log(10)
log(x, y)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/1b50b0c3-9898-41a7-a562-e2a6c3393468)


-- 自然数e为底的对数
loge(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/882b65fb-1fc5-45ea-9064-2f67655d4e10)


-- 10为底的对数
log10(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/6314388c-6e53-49c4-ab6e-78bef0557c59)


-- 平均值
avg(...)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/14c859b2-1144-4f54-9fe0-a497352c5fdf)


-- 方差
var(...)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/b8ae77f4-ee3c-4288-ae22-2f09b0d3b119)


-- 阶乘. 支持 12! 或者 fact(12) 两种调用方式
fact(x)
![图片](https://github.com/gaboolic/rime-shuangpin-fuzhuma/assets/26186575/968c5658-a904-469e-955a-7b8bf790cf92)
