### PR TITLE
fix:moqi_wan_zrm自造词失效的问题

### DIFF
--- a/moqi_wan_zrm.schema.yaml
+++ b/moqi_wan_zrm.schema.yaml
@@ -74,6 +74,9 @@ aux_patch:
     __include: moqi_speller.yaml:/common_aux
 
 __patch:
+  add_user_dict/dictionary: moqi_wan.extended
+  user_dict_set/dictionary: moqi_wan.extended
+  translator/prism: moqi_wan_zrm
   user_dict_set/prism: moqi_wan_zrm
   add_user_dict/prism: moqi_wan_zrm
   big_char_set/prism: moqi_wan_big_zrm


### PR DESCRIPTION
通过与小鹤版本的数据进行对比发现少了这三行配置，通过配置之后发现自造词功能可以正常使用了